### PR TITLE
修复搜索bug

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -194,10 +194,6 @@ export default {
   beforeRouteUpdate (to, from, next) {
     this.rightDrawerOpen = false
 
-    // 离开搜索页面时清空输入框
-    if (to.path.indexOf('search') === -1) {
-      this.keyword = ''
-    }
     next()
   }
 }


### PR DESCRIPTION
修复[这个bug](https://github.com/yodhcn/kikoeru-express/issues/4)。
原因：搜索以后点击卡片 => 触发变更搜索关键词为空 =>触发整个页面回到搜索空关键词的状况，即跳回主界面。